### PR TITLE
YAML + other improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Create a simple, cheap, CDN backed, static website using a single AWS CloudForma
     * WebsiteName
     * HostedZoneId (using the console, a list will be provided)
     --- 
-    * BucketName Optional, if you want to use an existing bucket.
+    * BucketName Optional, if you want to use an existing bucket. Cloudformation will generate a bucketname using the stackname-HTML-randomcharacters if left empty.
 1. Provision the CloudFormation stack using the console or with awscli:
 
     ```

--- a/README.md
+++ b/README.md
@@ -3,14 +3,28 @@ Create a simple, cheap, CDN backed, static website using a single AWS CloudForma
 
 ## Instructions
 1. Register a domain in AWS [here](https://console.aws.amazon.com/route53/home#DomainListing:)
-2. Created a Hosted Zone for that domain in [Route53](https://console.aws.amazon.com/route53/v2/hostedzones#)
-3. Request an SSL certificate for that domain in [ACM](https://console.aws.amazon.com/acm/home)
-4. Copy the ARN of the ACM certificate to your clipboard. It should have the format `arn:aws:acm:us-east-1:567800000000:certificate/1243abcd-xxxx-xxxx-xxxx-xxxxxxxxxxxx`
-5. Create a new [CloudFormation stack](https://console.aws.amazon.com/cloudformation/home?region=us-east-1) using the `simple-static-website.json` template. This *MUST* be done in `us-east-1` owing to constraints with CloudFront.
-6. Provide the three parameters: ACM arn, domain name for the website, Route53 hosted zone name
-7. Provision the CloudFormation stack
-8. Put a simple index.html file in the newly created [S3 bucket](https://s3.console.aws.amazon.com/s3/home)
-9. Visit your new website at the domain you provided in step 6
+1. Created a Hosted Zone for that domain in [Route53](https://console.aws.amazon.com/route53/v2/hostedzones#)
+1. Create a new [CloudFormation stack](https://console.aws.amazon.com/cloudformation/home?region=us-east-1) using the `simple-static-website.yaml` template. This *MUST* be done in `us-east-1` owing to constraints with CloudFront.
+1. Provide the parameters:
+    * DomainName
+    * WebsiteName
+    * HostedZoneId (using the console, a list will be provided)
+    --- 
+    * BucketName Optional, if you want to use an existing bucket.
+1. Provision the CloudFormation stack using the console or with awscli:
+
+    ```
+    ﬌ aws cloudformation deploy \
+        --stack-name foo \
+        --template-file simple-static-website.yaml \
+        --parameter-overrides \
+            DomainName=example.com \
+            HostedZoneId=ABCDEFGHIJK0123456789 \
+            WebsiteName=www
+    ```
+
+1. Put a simple index.html file in the newly created [S3 bucket](https://s3.console.aws.amazon.com/s3/home). Check Cloudformation output of the stack for a sample awscli command.
+1. Visit your new website at the domain you provided in step 6. Check Cloudformation output for URL.
 
 ## A note on using a Content Distribution Network (CDN)
 Remember that the CloudFront CDN will cache your website at several locations around the world. If you change your site, you will have to [invalidate the cache](https://www.simplified.guide/aws/cloudfront/invalidate-cache). Charges apply, but on the whole this is an extremely cheap setup because it doesn't run any servers.

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Create a simple, cheap, CDN backed, static website using a single AWS CloudForma
 1. Provision the CloudFormation stack using the console or with awscli:
 
     ```
-    ﬌ aws cloudformation deploy \
+    aws cloudformation deploy \
         --stack-name foo \
         --template-file simple-static-website.yaml \
         --parameter-overrides \

--- a/index.html
+++ b/index.html
@@ -1,0 +1,5 @@
+<html>
+    <body>
+        testing123
+    </body>
+</html>

--- a/simple-static-website.yaml
+++ b/simple-static-website.yaml
@@ -1,0 +1,167 @@
+---
+AWSTemplateFormatVersion: "2010-09-09"
+Description: Cloudfront-ed S3 Bucket
+Parameters:
+  WebsiteName:
+    Type: String
+    Description: E.g. the "www" in www.example.com
+  BucketName:
+    Type: String
+    Default: ""
+    Description: If not supplied, a bucket will be created and name after the stack
+  DomainName:
+    Type: String
+    Description: E.g. "example.com" in www.example.com
+  HostedZoneId:
+    Type: AWS::Route53::HostedZone::Id
+    Description: You must already have a Hosted Zone setup for your domain in Route53.
+Metadata:
+  AWS::CloudFormation::Interface:
+    ParameterGroups:
+      - Label:
+          default: DNS
+        Parameters:
+          - HostedZoneId
+          - WebsiteName
+          - DomainName
+      - Label:
+          default: Optional
+        Parameters:
+          - BucketName
+    ParameterLabels:
+      BucketName:
+        default: Existing S3 Bucket Name
+      DomainName:
+        default: Domain Name
+      WebsiteName:
+        default: Website Name
+      HostedZoneId:
+        default: Hosted Zone Id
+Conditions:
+  BucketNameEmpty: !Equals [!Ref BucketName, ""]
+Resources:
+  Certificate:
+    Type: AWS::CertificateManager::Certificate
+    Properties:
+      DomainName: !Sub ${WebsiteName}.${DomainName}
+      DomainValidationOptions:
+        - DomainName: !Sub ${WebsiteName}.${DomainName}
+          HostedZoneId: !Ref HostedZoneId
+      ValidationMethod: DNS
+  CloudFrontIdentity:
+    Type: AWS::CloudFront::CloudFrontOriginAccessIdentity
+    Properties:
+      CloudFrontOriginAccessIdentityConfig:
+        Comment: Simple Website Origin Access Identity
+  ARecordSet:
+    Type: AWS::Route53::RecordSet
+    Properties:
+      AliasTarget:
+        HostedZoneId: Z2FDTNDATAQYW2
+        DNSName: !GetAtt DistributionCloudFrontNet.DomainName
+      HostedZoneId: !Ref HostedZoneId
+      Name: !Sub ${WebsiteName}.${DomainName}
+      Type: A
+  AAAARecordSet:
+    Type: AWS::Route53::RecordSet
+    Properties:
+      AliasTarget:
+        HostedZoneId: Z2FDTNDATAQYW2
+        DNSName: !GetAtt DistributionCloudFrontNet.DomainName
+      HostedZoneId: !Ref HostedZoneId
+      Name: !Sub ${WebsiteName}.${DomainName}
+      Type: AAAA
+  HTML:
+    Type: AWS::S3::Bucket
+    Condition: BucketNameEmpty
+    Properties:
+      WebsiteConfiguration:
+        IndexDocument: index.html
+    DeletionPolicy: Retain
+    UpdateReplacePolicy: Retain
+  DistributionCloudFrontNet:
+    Type: AWS::CloudFront::Distribution
+    Properties:
+      DistributionConfig:
+        Aliases:
+          - !Sub ${WebsiteName}.${DomainName}
+        Enabled: true
+        HttpVersion: http2
+        PriceClass: PriceClass_100
+        DefaultRootObject: index.html
+        DefaultCacheBehavior:
+          TargetOriginId:
+            !If [
+              BucketNameEmpty,
+              !Sub "S3-origin-${HTML}",
+              !Sub "S3-origin-${BucketName}",
+            ]
+          ViewerProtocolPolicy: redirect-to-https
+          AllowedMethods:
+            - HEAD
+            - GET
+          CachedMethods:
+            - HEAD
+            - GET
+          ForwardedValues:
+            Cookies:
+              Forward: none
+            QueryString: true
+        Origins:
+          - DomainName:
+              !If [
+                BucketNameEmpty,
+                !GetAtt HTML.RegionalDomainName,
+                !Sub "${BucketName}.s3.us-east-1.amazonaws.com",
+              ]
+            Id:
+              !If [
+                BucketNameEmpty,
+                !Sub "S3-origin-${HTML}",
+                !Sub "S3-origin-${BucketName}",
+              ]
+            S3OriginConfig:
+              OriginAccessIdentity:
+                Fn::Sub: origin-access-identity/cloudfront/${CloudFrontIdentity}
+        Restrictions:
+          GeoRestriction:
+            RestrictionType: none
+            Locations: []
+        ViewerCertificate:
+          SslSupportMethod: sni-only
+          MinimumProtocolVersion: TLSv1.2_2021
+          AcmCertificateArn: !Ref Certificate
+  BucketPolicy:
+    Type: AWS::S3::BucketPolicy
+    Properties:
+      Bucket: !If [
+                BucketNameEmpty,
+                !Ref HTML,
+                !Ref BucketName,
+              ]
+      PolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Principal:
+              AWS: !Sub "arn:aws:iam::cloudfront:user/CloudFront Origin Access Identity ${CloudFrontIdentity}"
+            Action: s3:GetObject
+            Resource: !If [
+                BucketNameEmpty,
+                !Sub "arn:aws:s3:::${HTML}/*",
+                !Sub "arn:aws:s3:::${BucketName}/*",
+              ]
+Outputs:
+  Route53URL:
+    Value: !Sub https://${ARecordSet}
+    Description: Simple website URL (remember to put some HTML in the S3 bucket)
+  CloudFrontURL:
+    Value: !GetAtt DistributionCloudFrontNet.DomainName
+    Description: CloudFront URL
+  Upload:
+    Value: !If [
+                BucketNameEmpty,
+                !Sub "aws s3 cp index.html s3://${HTML}",
+                !Sub "aws s3 cp index.html s3://${BucketName}",
+              ]
+    Description: Upload your first file


### PR DESCRIPTION
* Number one, don't torture humans with JSON :smile: 
* User can now supply their own pre-existing bucket or let cloudformation create one for them. S3 is a "global namespace" so each bucket name must be unique. Previous code was based of websitename which in my initial test "testing.example.com", the testing bucket already existed
* Provided cli command for deployment
* Cloudformation template now outputs https url and example aws cli s3 command to copy the basic index.html provided.
* IPV6 AAAA dns record
* Lots of cfn improvements (make sure you use cfnlint!) but you should note the use of Conditions and Sub instead of Join.