### PR TITLE
feat(oa): remove Origin Access Control

### DIFF
--- a/simple-static-website.json
+++ b/simple-static-website.json
@@ -88,18 +88,6 @@
               "ValidationMethod": "DNS"
           }
       },
-      "OriginAccessControl": {
-          "Type": "AWS::CloudFront::OriginAccessControl",
-          "Properties": {
-              "OriginAccessControlConfig": {
-                  "Name": "Simple Website Origin Access Control",
-                  "Description": "OAC for Simple Website",
-                  "OriginAccessControlOriginType": "s3",
-                  "SigningBehavior": "always",
-                  "SigningProtocol": "sigv4"
-              }
-          }
-      },
       "ARecordSet": {
           "Type": "AWS::Route53::RecordSet",
           "Properties": {
@@ -151,6 +139,12 @@
               },
               "BucketName": {
                   "Fn::Sub": "${WebsiteName}.${DomainName}"
+              },
+              "PublicAccessBlockConfiguration": {
+                "BlockPublicAcls": false,
+                "BlockPublicPolicy": false,
+                "IgnorePublicAcls": false,
+                "RestrictPublicBuckets": false
               }
           },
           "DeletionPolicy": "Retain",
@@ -437,13 +431,10 @@
                               "Fn::If": [
                                   "BucketNameEmpty",
                                   {
-                                      "Fn::GetAtt": [
-                                          "HTML",
-                                          "RegionalDomainName"
-                                      ]
+                                      "Fn::Sub": "${HTML}.s3-website-${AWS::Region}.amazonaws.com"
                                   },
                                   {
-                                      "Fn::Sub": "${BucketName}.s3.us-east-1.amazonaws.com"
+                                      "Fn::Sub": "${BucketName}.s3-website-${AWS::Region}.amazonaws.com"
                                   }
                               ]
                           },
@@ -458,12 +449,9 @@
                                   }
                               ]
                           },
-                          "S3OriginConfig": {},
-                          "OriginAccessControlId": {
-                              "Fn::GetAtt": [
-                                  "OriginAccessControl",
-                                  "Id"
-                              ]
+                          "CustomOriginConfig": {
+                            "HTTPPort": 80,
+                            "OriginProtocolPolicy": "http-only"
                           }
                       }
                   ],
@@ -502,9 +490,7 @@
                   "Statement": [
                       {
                           "Effect": "Allow",
-                          "Principal": {
-                              "Service": "cloudfront.amazonaws.com"
-                          },
+                          "Principal": "*",
                           "Action": "s3:GetObject",
                           "Resource": {
                               "Fn::If": [
@@ -516,13 +502,6 @@
                                       "Fn::Sub": "arn:aws:s3:::${BucketName}/*"
                                   }
                               ]
-                          },
-                          "Condition": {
-                              "StringEquals": {
-                                  "AWS:SourceArn": {
-                                      "Fn::Sub": "arn:aws:cloudfront::${AWS::AccountId}:distribution/${DistributionCloudFrontNet}"
-                                  }
-                              }
                           }
                       }
                   ]

--- a/simple-static-website.yaml
+++ b/simple-static-website.yaml
@@ -48,15 +48,6 @@ Resources:
         - DomainName: !Sub ${WebsiteName}.${DomainName}
           HostedZoneId: !Ref HostedZoneId
       ValidationMethod: DNS
-  OriginAccessControl:
-    Type: AWS::CloudFront::OriginAccessControl
-    Properties:
-      OriginAccessControlConfig:
-        Name: Simple Website Origin Access Control
-        Description: OAC for Simple Website
-        OriginAccessControlOriginType: s3
-        SigningBehavior: always
-        SigningProtocol: sigv4
   ARecordSet:
     Type: AWS::Route53::RecordSet
     Properties:
@@ -82,6 +73,11 @@ Resources:
       WebsiteConfiguration:
         IndexDocument: index.html
       BucketName: !Sub ${WebsiteName}.${DomainName}
+      PublicAccessBlockConfiguration:
+        BlockPublicAcls: false
+        BlockPublicPolicy: false
+        IgnorePublicAcls: false
+        RestrictPublicBuckets: false
     DeletionPolicy: Retain
     UpdateReplacePolicy: Retain
   ResponseHeadersPolicy:
@@ -250,8 +246,8 @@ Resources:
           - DomainName:
               !If [
                 BucketNameEmpty,
-                !GetAtt HTML.RegionalDomainName,
-                !Sub "${BucketName}.s3.us-east-1.amazonaws.com",
+                !Sub "${HTML}.s3-website-${AWS::Region}.amazonaws.com",
+                !Sub "${BucketName}.s3-website-${AWS::Region}.amazonaws.com",
               ]
             Id:
               !If [
@@ -259,8 +255,9 @@ Resources:
                 !Sub "S3-origin-${HTML}",
                 !Sub "S3-origin-${BucketName}",
               ]
-            S3OriginConfig: {}
-            OriginAccessControlId: !GetAtt OriginAccessControl.Id
+            CustomOriginConfig:
+              HTTPPort: 80
+              OriginProtocolPolicy: http-only
         Restrictions:
           GeoRestriction:
             RestrictionType: none
@@ -281,17 +278,13 @@ Resources:
         Version: "2012-10-17"
         Statement:
           - Effect: Allow
-            Principal:
-              Service: cloudfront.amazonaws.com
+            Principal: "*"
             Action: s3:GetObject
             Resource: !If [
                 BucketNameEmpty,
                 !Sub "arn:aws:s3:::${HTML}/*",
                 !Sub "arn:aws:s3:::${BucketName}/*",
               ]
-            Condition:
-              StringEquals:
-                "AWS:SourceArn": !Sub "arn:aws:cloudfront::${AWS::AccountId}:distribution/${DistributionCloudFrontNet}"
 Outputs:
   Route53URL:
     Value: !Sub https://${ARecordSet}


### PR DESCRIPTION
Routing within Next.js is fundamentally incompatible with Origin Access Control. Reverting to unrestricted public access to the underlying S3 bucket.
