### PR TITLE
feat(oac): revert to Origin Access Control

### DIFF
--- a/simple-static-website.json
+++ b/simple-static-website.json
@@ -205,6 +205,200 @@
                           "ErrorCachingMinTTL": 300
                       }
                   ],
+                  "CacheBehaviors": [
+                      {
+                          "PathPattern": "*.css",
+                          "TargetOriginId": {
+                              "Fn::If": [
+                                  "BucketNameEmpty",
+                                  {
+                                      "Fn::Sub": "S3-origin-${HTML}"
+                                  },
+                                  {
+                                      "Fn::Sub": "S3-origin-${BucketName}"
+                                  }
+                              ]
+                          },
+                          "ViewerProtocolPolicy": "redirect-to-https",
+                          "CachePolicyId": "658327ea-f89d-4fab-a63d-7e88639e58f6"
+                      },
+                      {
+                          "PathPattern": "*.js",
+                          "TargetOriginId": {
+                              "Fn::If": [
+                                  "BucketNameEmpty",
+                                  {
+                                      "Fn::Sub": "S3-origin-${HTML}"
+                                  },
+                                  {
+                                      "Fn::Sub": "S3-origin-${BucketName}"
+                                  }
+                              ]
+                          },
+                          "ViewerProtocolPolicy": "redirect-to-https",
+                          "CachePolicyId": "658327ea-f89d-4fab-a63d-7e88639e58f6"
+                      },
+                      {
+                          "PathPattern": "*.jpg",
+                          "TargetOriginId": {
+                              "Fn::If": [
+                                  "BucketNameEmpty",
+                                  {
+                                      "Fn::Sub": "S3-origin-${HTML}"
+                                  },
+                                  {
+                                      "Fn::Sub": "S3-origin-${BucketName}"
+                                  }
+                              ]
+                          },
+                          "ViewerProtocolPolicy": "redirect-to-https",
+                          "CachePolicyId": "658327ea-f89d-4fab-a63d-7e88639e58f6"
+                      },
+                      {
+                          "PathPattern": "*.jpeg",
+                          "TargetOriginId": {
+                              "Fn::If": [
+                                  "BucketNameEmpty",
+                                  {
+                                      "Fn::Sub": "S3-origin-${HTML}"
+                                  },
+                                  {
+                                      "Fn::Sub": "S3-origin-${BucketName}"
+                                  }
+                              ]
+                          },
+                          "ViewerProtocolPolicy": "redirect-to-https",
+                          "CachePolicyId": "658327ea-f89d-4fab-a63d-7e88639e58f6"
+                      },
+                      {
+                          "PathPattern": "*.png",
+                          "TargetOriginId": {
+                              "Fn::If": [
+                                  "BucketNameEmpty",
+                                  {
+                                      "Fn::Sub": "S3-origin-${HTML}"
+                                  },
+                                  {
+                                      "Fn::Sub": "S3-origin-${BucketName}"
+                                  }
+                              ]
+                          },
+                          "ViewerProtocolPolicy": "redirect-to-https",
+                          "CachePolicyId": "658327ea-f89d-4fab-a63d-7e88639e58f6"
+                      },
+                      {
+                          "PathPattern": "*.gif",
+                          "TargetOriginId": {
+                              "Fn::If": [
+                                  "BucketNameEmpty",
+                                  {
+                                      "Fn::Sub": "S3-origin-${HTML}"
+                                  },
+                                  {
+                                      "Fn::Sub": "S3-origin-${BucketName}"
+                                  }
+                              ]
+                          },
+                          "ViewerProtocolPolicy": "redirect-to-https",
+                          "CachePolicyId": "658327ea-f89d-4fab-a63d-7e88639e58f6"
+                      },
+                      {
+                          "PathPattern": "*.ico",
+                          "TargetOriginId": {
+                              "Fn::If": [
+                                  "BucketNameEmpty",
+                                  {
+                                      "Fn::Sub": "S3-origin-${HTML}"
+                                  },
+                                  {
+                                      "Fn::Sub": "S3-origin-${BucketName}"
+                                  }
+                              ]
+                          },
+                          "ViewerProtocolPolicy": "redirect-to-https",
+                          "CachePolicyId": "658327ea-f89d-4fab-a63d-7e88639e58f6"
+                      },
+                      {
+                          "PathPattern": "*.svg",
+                          "TargetOriginId": {
+                              "Fn::If": [
+                                  "BucketNameEmpty",
+                                  {
+                                      "Fn::Sub": "S3-origin-${HTML}"
+                                  },
+                                  {
+                                      "Fn::Sub": "S3-origin-${BucketName}"
+                                  }
+                              ]
+                          },
+                          "ViewerProtocolPolicy": "redirect-to-https",
+                          "CachePolicyId": "658327ea-f89d-4fab-a63d-7e88639e58f6"
+                      },
+                      {
+                          "PathPattern": "*.woff",
+                          "TargetOriginId": {
+                              "Fn::If": [
+                                  "BucketNameEmpty",
+                                  {
+                                      "Fn::Sub": "S3-origin-${HTML}"
+                                  },
+                                  {
+                                      "Fn::Sub": "S3-origin-${BucketName}"
+                                  }
+                              ]
+                          },
+                          "ViewerProtocolPolicy": "redirect-to-https",
+                          "CachePolicyId": "658327ea-f89d-4fab-a63d-7e88639e58f6"
+                      },
+                      {
+                          "PathPattern": "*.woff2",
+                          "TargetOriginId": {
+                              "Fn::If": [
+                                  "BucketNameEmpty",
+                                  {
+                                      "Fn::Sub": "S3-origin-${HTML}"
+                                  },
+                                  {
+                                      "Fn::Sub": "S3-origin-${BucketName}"
+                                  }
+                              ]
+                          },
+                          "ViewerProtocolPolicy": "redirect-to-https",
+                          "CachePolicyId": "658327ea-f89d-4fab-a63d-7e88639e58f6"
+                      },
+                      {
+                          "PathPattern": "*.ttf",
+                          "TargetOriginId": {
+                              "Fn::If": [
+                                  "BucketNameEmpty",
+                                  {
+                                      "Fn::Sub": "S3-origin-${HTML}"
+                                  },
+                                  {
+                                      "Fn::Sub": "S3-origin-${BucketName}"
+                                  }
+                              ]
+                          },
+                          "ViewerProtocolPolicy": "redirect-to-https",
+                          "CachePolicyId": "658327ea-f89d-4fab-a63d-7e88639e58f6"
+                      },
+                      {
+                          "PathPattern": "*.webp",
+                          "TargetOriginId": {
+                              "Fn::If": [
+                                  "BucketNameEmpty",
+                                  {
+                                      "Fn::Sub": "S3-origin-${HTML}"
+                                  },
+                                  {
+                                      "Fn::Sub": "S3-origin-${BucketName}"
+                                  }
+                              ]
+                          },
+                          "ViewerProtocolPolicy": "redirect-to-https",
+                          "CachePolicyId": "658327ea-f89d-4fab-a63d-7e88639e58f6"
+                      }
+                  ],
                   "DefaultCacheBehavior": {
                       "TargetOriginId": {
                           "Fn::If": [
@@ -226,12 +420,7 @@
                           "HEAD",
                           "GET"
                       ],
-                      "ForwardedValues": {
-                        "QueryString": false,
-                        "Cookies": {
-                            "Forward": "none"
-                        }
-                      },
+                      "CachePolicyId": "4135ea2d-6df8-44a3-9df3-4b5a84be39ad",
                       "ResponseHeadersPolicyId": {
                           "Ref": "ResponseHeadersPolicy"
                       }

--- a/simple-static-website.yaml
+++ b/simple-static-website.yaml
@@ -117,6 +117,115 @@ Resources:
             ResponseCode: 404
             ResponsePagePath: /404.html
             ErrorCachingMinTTL: 300
+        CacheBehaviors:
+          - PathPattern: "*.css"
+            TargetOriginId:
+              !If [
+                BucketNameEmpty,
+                !Sub "S3-origin-${HTML}",
+                !Sub "S3-origin-${BucketName}",
+              ]
+            ViewerProtocolPolicy: redirect-to-https
+            CachePolicyId: 658327ea-f89d-4fab-a63d-7e88639e58f6
+          - PathPattern: "*.js"
+            TargetOriginId:
+              !If [
+                BucketNameEmpty,
+                !Sub "S3-origin-${HTML}",
+                !Sub "S3-origin-${BucketName}",
+              ]
+            ViewerProtocolPolicy: redirect-to-https
+            CachePolicyId: 658327ea-f89d-4fab-a63d-7e88639e58f6
+          - PathPattern: "*.jpg"
+            TargetOriginId:
+              !If [
+                BucketNameEmpty,
+                !Sub "S3-origin-${HTML}",
+                !Sub "S3-origin-${BucketName}",
+              ]
+            ViewerProtocolPolicy: redirect-to-https
+            CachePolicyId: 658327ea-f89d-4fab-a63d-7e88639e58f6
+          - PathPattern: "*.jpeg"
+            TargetOriginId:
+              !If [
+                BucketNameEmpty,
+                !Sub "S3-origin-${HTML}",
+                !Sub "S3-origin-${BucketName}",
+              ]
+            ViewerProtocolPolicy: redirect-to-https
+            CachePolicyId: 658327ea-f89d-4fab-a63d-7e88639e58f6
+          - PathPattern: "*.png"
+            TargetOriginId:
+              !If [
+                BucketNameEmpty,
+                !Sub "S3-origin-${HTML}",
+                !Sub "S3-origin-${BucketName}",
+              ]
+            ViewerProtocolPolicy: redirect-to-https
+            CachePolicyId: 658327ea-f89d-4fab-a63d-7e88639e58f6
+          - PathPattern: "*.gif"
+            TargetOriginId:
+              !If [
+                BucketNameEmpty,
+                !Sub "S3-origin-${HTML}",
+                !Sub "S3-origin-${BucketName}",
+              ]
+            ViewerProtocolPolicy: redirect-to-https
+            CachePolicyId: 658327ea-f89d-4fab-a63d-7e88639e58f6
+          - PathPattern: "*.ico"
+            TargetOriginId:
+              !If [
+                BucketNameEmpty,
+                !Sub "S3-origin-${HTML}",
+                !Sub "S3-origin-${BucketName}",
+              ]
+            ViewerProtocolPolicy: redirect-to-https
+            CachePolicyId: 658327ea-f89d-4fab-a63d-7e88639e58f6
+          - PathPattern: "*.svg"
+            TargetOriginId:
+              !If [
+                BucketNameEmpty,
+                !Sub "S3-origin-${HTML}",
+                !Sub "S3-origin-${BucketName}",
+              ]
+            ViewerProtocolPolicy: redirect-to-https
+            CachePolicyId: 658327ea-f89d-4fab-a63d-7e88639e58f6
+          - PathPattern: "*.woff"
+            TargetOriginId:
+              !If [
+                BucketNameEmpty,
+                !Sub "S3-origin-${HTML}",
+                !Sub "S3-origin-${BucketName}",
+              ]
+            ViewerProtocolPolicy: redirect-to-https
+            CachePolicyId: 658327ea-f89d-4fab-a63d-7e88639e58f6
+          - PathPattern: "*.woff2"
+            TargetOriginId:
+              !If [
+                BucketNameEmpty,
+                !Sub "S3-origin-${HTML}",
+                !Sub "S3-origin-${BucketName}",
+              ]
+            ViewerProtocolPolicy: redirect-to-https
+            CachePolicyId: 658327ea-f89d-4fab-a63d-7e88639e58f6
+          - PathPattern: "*.ttf"
+            TargetOriginId:
+              !If [
+                BucketNameEmpty,
+                !Sub "S3-origin-${HTML}",
+                !Sub "S3-origin-${BucketName}",
+              ]
+            ViewerProtocolPolicy: redirect-to-https
+            CachePolicyId: 658327ea-f89d-4fab-a63d-7e88639e58f6
+          - PathPattern: "*.webp"
+            TargetOriginId:
+              !If [
+                BucketNameEmpty,
+                !Sub "S3-origin-${HTML}",
+                !Sub "S3-origin-${BucketName}",
+              ]
+            ViewerProtocolPolicy: redirect-to-https
+            CachePolicyId: 658327ea-f89d-4fab-a63d-7e88639e58f6
         DefaultCacheBehavior:
           TargetOriginId:
             !If [
@@ -131,10 +240,7 @@ Resources:
           CachedMethods:
             - HEAD
             - GET
-          ForwardedValues:
-            QueryString: false
-            Cookies:
-              Forward: none
+          CachePolicyId: 4135ea2d-6df8-44a3-9df3-4b5a84be39ad
           ResponseHeadersPolicyId: !Ref ResponseHeadersPolicy
         Origins:
           - DomainName:


### PR DESCRIPTION
Modern static sites can be built using Next.js etc. by adding a CloudFront script to a distribution, https://github.com/lifebeyondfife/blog/blob/main/scripts/cloudfront-redirect-oac.js

